### PR TITLE
Fix bumpversion in pyproject and add README

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.0
+current_version = 0.1.1
 commit = True
 tag = False
 

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,7 +1,0 @@
-[bumpversion]
-current_version = 0.1.0
-commit = True
-tag = False
-
-[bumpversion:file:pyproject.toml]
-[bumpversion:file:.github/workflows/docker.yaml]

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.1
+current_version = 0.1.0
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ on:
 permissions: {}
 
 env:
-  VERSION: 0.1.1
+  VERSION: 0.1.0
   IMAGE_NAME: cpg_flow_stripy
   DOCKER_DEV: australia-southeast1-docker.pkg.dev/cpg-common/images-dev
   DOCKER_MAIN: australia-southeast1-docker.pkg.dev/cpg-common/images

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ on:
 permissions: {}
 
 env:
-  VERSION: 0.1.0
+  VERSION: 0.1.1
   IMAGE_NAME: cpg_flow_stripy
   DOCKER_DEV: australia-southeast1-docker.pkg.dev/cpg-common/images-dev
   DOCKER_MAIN: australia-southeast1-docker.pkg.dev/cpg-common/images

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,13 +17,14 @@ repos:
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.3.3
+    rev: v0.12.0
     hooks:
       - id: ruff
+      - id: ruff-format
 
   # Static type analysis (as much as it's possible in python using type hints)
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: "v1.9.0"
+    rev: "v1.10.0"
     hooks:
       - id: mypy
         args: [--pretty, --show-error-codes, --install-types, --non-interactive]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
-# cpg_flow_stripy
+# CPG Flow Stripy
+
+A CPG workflow for creating STR reports with STRipy, using the [cpg-flow](https://github.com/populationgenomics/cpg-flow) pipeline framework.
+
+## Purpose
+
+This workflow is designed to process short-read sequencing data and create reports with [STRipy](https://gitlab.com/andreassh/stripy-pipeline).
+
+The short-read data is processed at the sequencing group level, and STRipy reports are generated for each sequencing group. The configuration allows complete customisation as to which STR loci are analysed and which reports are created.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,7 +99,7 @@ cpg = ["cpg-flow", "cpg-utils"]
 hail = ["hail"]
 
 [tool.bumpversion]
-current_version = "0.1.7"
+current_version = "0.1.0"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 commit = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name='cpg_flow_stripy'
 description='STR calling and report generation, implemented in CPG-Flow'
 readme = "README.md"
 requires-python = ">=3.10,<3.11"
-version='0.1.0'
+version='0.1.1'
 license={ "file" = "LICENSE" }
 classifiers=[
     'Environment :: Console',
@@ -99,7 +99,7 @@ cpg = ["cpg-flow", "cpg-utils"]
 hail = ["hail"]
 
 [tool.bumpversion]
-current_version = "0.1.0"
+current_version = "0.1.1"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 commit = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,7 +99,7 @@ cpg = ["cpg-flow", "cpg-utils"]
 hail = ["hail"]
 
 [tool.bumpversion]
-current_version = "0.1.1"
+current_version = "0.1.0"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 commit = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name='cpg_flow_stripy'
 description='STR calling and report generation, implemented in CPG-Flow'
 readme = "README.md"
 requires-python = ">=3.10,<3.11"
-version='0.1.1'
+version='0.1.0'
 license={ "file" = "LICENSE" }
 classifiers=[
     'Environment :: Console',

--- a/src/cpg_flow_stripy/stages.py
+++ b/src/cpg_flow_stripy/stages.py
@@ -16,7 +16,7 @@ def _update_meta(output_path: str) -> dict[str, Any]:
     """
     Add the detected outlier loci to the analysis meta
     """
-    from cloudpathlib.anypath import to_anypath
+    from cloudpathlib.anypath import to_anypath  # noqa: PLC0415
 
     # Munge html path into log path (As far as I can know I can not pass to
     # output paths to one analysis object?)


### PR DESCRIPTION
# Purpose

  - Fix the version in pyproject.toml so it's aligned with what's in bumpversion.cfg and the gh workflow (v0.1.0)
  - Update pre-commit hooks to latest versions
  - Remove `.bumpversion.cfg` file used by `bumpversion` (not needed with bump-2-version)
  - Add something generic for the readme
