### PR TITLE
technology filter and better error handling

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,7 @@
+[bumpversion]
+current_version = 0.1.0
+commit = True
+tag = False
+
+[bumpversion:file:pyproject.toml]
+[bumpversion:file:.github/workflows/docker.yaml]

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.2.1
+current_version = 0.2.2
 commit = True
 tag = False
 

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.0
+current_version = 0.2.1
 commit = True
 tag = False
 

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -4,4 +4,3 @@ commit = True
 tag = False
 
 [bumpversion:file:pyproject.toml]
-[bumpversion:file:.github/workflows/docker.yaml]

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,6 +1,0 @@
-[bumpversion]
-current_version = 0.2.2
-commit = True
-tag = False
-
-[bumpversion:file:pyproject.toml]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM australia-southeast1-docker.pkg.dev/cpg-common/images/cpg_hail_gcloud:0.2.134.cpg2-2
 
 ENV PYTHONDONTWRITEBYTECODE=1
-ENV VERSION=0.2.1
+ENV VERSION=0.2.2
 
 WORKDIR /cpg_flow_stripy
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # CPG Flow Stripy
-#--image  australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-stripy:0.2.1-2
+#--image  australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-stripy:0.2.2-1
 A CPG workflow for creating STR reports with STRipy, using the [cpg-flow](https://github.com/populationgenomics/cpg-flow) pipeline framework.
 
 ## Purpose
@@ -13,7 +13,7 @@ The short-read data is processed at the sequencing group level, and STRipy repor
 ```bash
 analysis-runner \
     --skip-repo-checkout \
-    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-stripy:0.2.1-2\
+    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-stripy:0.2.2-1\
     --config src/cpg_flow_stripy/config_template.toml \
     --config stripy_loci.toml \  # containing the inputs_cohorts and sequencing_type
     --dataset seqr \

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # CPG Flow Stripy
-
+#--image  australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-stripy:0.2.1-2
 A CPG workflow for creating STR reports with STRipy, using the [cpg-flow](https://github.com/populationgenomics/cpg-flow) pipeline framework.
 
 ## Purpose
@@ -13,7 +13,7 @@ The short-read data is processed at the sequencing group level, and STRipy repor
 ```bash
 analysis-runner \
     --skip-repo-checkout \
-    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-stripy:0.2.1 \
+    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-stripy:0.2.1-2\
     --config src/cpg_flow_stripy/config_template.toml \
     --config stripy_loci.toml \  # containing the inputs_cohorts and sequencing_type
     --dataset seqr \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name='cpg_flow_stripy'
 description='STR calling and report generation, implemented in CPG-Flow'
 readme = "README.md"
 requires-python = ">=3.10,<3.11"
-version="0.2.1"
+version="0.2.2"
 license={ "file" = "LICENSE" }
 classifiers=[
     'Environment :: Console',
@@ -96,7 +96,7 @@ cpg = ["cpg-flow", "cpg-utils"]
 hail = ["hail"]
 
 [tool.bumpversion]
-current_version = "0.2.1"
+current_version = "0.2.2"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 commit = true

--- a/src/cpg_flow_stripy/config_template.toml
+++ b/src/cpg_flow_stripy/config_template.toml
@@ -9,7 +9,7 @@ check_expected_outputs = true
 status_reporter = 'metamist'
 
 [images]
-stripy = "australia-southeast1-docker.pkg.dev/cpg-common/images/stripy:v2.5_ee4482bc-1"
+stripy = "australia-southeast1-docker.pkg.dev/cpg-common/images/stripy:v2.5_91a4ad-1"
 
 [stripy]
 # Analysis_type can be "standard" (fast) or "extended" (marginally slower but also uses unmapped reads for genotying)

--- a/src/cpg_flow_stripy/jobs/stripy.py
+++ b/src/cpg_flow_stripy/jobs/stripy.py
@@ -21,7 +21,7 @@ PEDIGREE_QUERY = gql(
     """
     query Pedigree($project: String!) {
         project(name: $project) {
-            sequencingGroups {
+            sequencingGroups(technology: {eq: "short-read"}) {
                 id
                 sample {
                     participant {
@@ -67,10 +67,6 @@ def get_cpg_to_family_mapping(data) -> dict[str, list[str]]:
         return id_map
 
     for group in sequencing_groups:
-        # Filter for short-read technology only
-        if group.get('technology') != 'short-read':
-            continue
-
         cpg_id = group.get('id')
 
         # Validate all required IDs are present


### PR DESCRIPTION
Adding a filter ro only use samples with short read technology and printing the sample ID when the script fails, so we know which samples dont have a family ID

## Checklist

- [ ] Related GitHub Issue created
- [ ] Tests covering new change
- [ ] Linting checks pass
