### PR TITLE
Move on from resources.open_text

### DIFF
--- a/src/cpg_flow_stripy/scripts/make_stripy_reports.py
+++ b/src/cpg_flow_stripy/scripts/make_stripy_reports.py
@@ -184,7 +184,7 @@ def main(
     # --- Generate HTML Output ---
     # This script writes the final HTML to the --output path
     with (
-        resources.open_text('cpg_flow_stripy', 'results_template.html') as results_html_template,
+        (resources.files('cpg_flow_stripy') / 'results_template.html').open() as results_html_template,
         open(output, 'w') as output_html_file,
     ):
         for line in results_html_template:


### PR DESCRIPTION
# Purpose

  - old resources.open_text method is deprecated

> DeprecationWarning: open_text is deprecated. Use files() instead. Refer to https://importlib-resources.readthedocs.io/en/latest/using.html#migrating-from-legacy for migration advice.
  
## Proposed Changes

  - replace with newer syntax