### PR TITLE
RD-1050 str joint call

### DIFF
--- a/.github/workflows/dev_auto_build.yaml
+++ b/.github/workflows/dev_auto_build.yaml
@@ -23,7 +23,6 @@ jobs:
   get_next_version:
     runs-on: ubuntu-latest
     environment: development
-    if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
     outputs:
       matrix: ${{ steps.get_next_version.outputs.next_version }}
     steps:

--- a/.github/workflows/dev_auto_build.yaml
+++ b/.github/workflows/dev_auto_build.yaml
@@ -1,13 +1,15 @@
 name: Autobuild development image
-on:
-  push:
-    branches-ignore:
-      - main
-  workflow_dispatch:
+
+on: [pull_request]
 
 permissions:
   id-token: write
   contents: read
+
+# only build one set of images in the event of multiple pushes in quick succession
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
 
 env:
   PROJECT: 'cpg-common'
@@ -59,7 +61,7 @@ jobs:
     environment: development
     needs:
       - get_next_version
-    if: ${{ needs.get_next_version.outputs.matrix != '{"include":[]}' && needs.get_next_version.outputs.matrix != '' && github.event_name == 'push' }}
+    if: ${{ needs.get_next_version.outputs.matrix != '{"include":[]}' && needs.get_next_version.outputs.matrix != '' && github.event.pull_request.draft == false }}
     strategy:
       matrix: ${{ fromJson(needs.get_next_version.outputs.matrix) }}
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM australia-southeast1-docker.pkg.dev/cpg-common/images/cpg_hail_gcloud:0.2.138.cpg1-1
 
 ENV PYTHONDONTWRITEBYTECODE=1
-ENV VERSION=0.3.2
+ENV VERSION=0.3.3
 
 WORKDIR /cpg_flow_stripy
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM australia-southeast1-docker.pkg.dev/cpg-common/images/cpg_hail_gcloud:0.2.137.cpg1-2
+FROM australia-southeast1-docker.pkg.dev/cpg-common/images/cpg_hail_gcloud:0.2.138.cpg1-1
 
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV VERSION=0.3.2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM australia-southeast1-docker.pkg.dev/cpg-common/images/cpg_hail_gcloud:0.2.138.cpg1-1
 
 ENV PYTHONDONTWRITEBYTECODE=1
-ENV VERSION=0.3.3
+ENV VERSION=0.4.0
 
 WORKDIR /cpg_flow_stripy
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The short-read data is processed at the sequencing group level, and STRipy repor
 ```bash
 analysis-runner \
     --skip-repo-checkout \
-    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-stripy:0.3.3-1 \
+    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-stripy:0.4.0-1 \
     --config src/cpg_flow_stripy/config_template.toml \
     --config stripy_loci.toml \  # containing the inputs_cohorts and sequencing_type
     --dataset seqr \

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The short-read data is processed at the sequencing group level, and STRipy repor
 ```bash
 analysis-runner \
     --skip-repo-checkout \
-    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-stripy:0.3.2-1 \
+    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-stripy:0.3.3-1 \
     --config src/cpg_flow_stripy/config_template.toml \
     --config stripy_loci.toml \  # containing the inputs_cohorts and sequencing_type
     --dataset seqr \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers=[
 ]
 
 dependencies=[
-    'cpg-flow~=1.3.1',
+    'cpg-flow~=1.3',
     'jinja2',
     'pysam',
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,9 @@ classifiers=[
 
 dependencies=[
     'cpg-flow~=1.3.1',
-    'jinja2'
+    'jinja2',
+    'pyfaidx',
+    'pysam',
 ]
 
 [project.urls]
@@ -54,6 +56,7 @@ ignore_missing_imports = true
 
 [tool.pytest.ini_options]
 testpaths = ['test']
+pythonpath = ['src']
 
 [tool.ruff]
 line-length = 120

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name='cpg_flow_stripy'
 description='STR calling and report generation, implemented in CPG-Flow'
 readme = "README.md"
 requires-python = ">=3.10,<3.12"
-version="0.3.3"
+version="0.4.0"
 license={ "file" = "LICENSE" }
 classifiers=[
     'Environment :: Console',
@@ -95,7 +95,7 @@ hail = ["hail"]
 inline-quotes = "single"
 
 [tool.bumpversion]
-current_version = "0.3.3"
+current_version = "0.4.0"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 commit = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name='cpg_flow_stripy'
 description='STR calling and report generation, implemented in CPG-Flow'
 readme = "README.md"
 requires-python = ">=3.10,<3.12"
-version="0.3.2"
+version="0.3.3"
 license={ "file" = "LICENSE" }
 classifiers=[
     'Environment :: Console',
@@ -95,7 +95,7 @@ hail = ["hail"]
 inline-quotes = "single"
 
 [tool.bumpversion]
-current_version = "0.3.2"
+current_version = "0.3.3"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 commit = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,6 @@ classifiers=[
 dependencies=[
     'cpg-flow~=1.3.1',
     'jinja2',
-    'pyfaidx',
     'pysam',
 ]
 
@@ -89,7 +88,7 @@ ignore = [
 section-order = ["future", "standard-library", "third-party", "hail", "cpg", "first-party", "local-folder"]
 
 [tool.ruff.lint.isort.sections]
-cpg = ["cpg-flow", "cpg-utils"]
+cpg = ["cpg_flow", "cpg_utils"]
 hail = ["hail"]
 
 [lint.flake8-quotes]

--- a/src/cpg_flow_stripy/config_template.toml
+++ b/src/cpg_flow_stripy/config_template.toml
@@ -23,3 +23,6 @@ log_flag_threshold = -1
 output_html = true
 output_json = true
 verbose = true
+
+[references]
+ensembl_gff3 = "gs://cpg-common-main/references/ensembl_116/GRCh38_chrM_renamed.gff3.gz"

--- a/src/cpg_flow_stripy/jobs/convert_gff.py
+++ b/src/cpg_flow_stripy/jobs/convert_gff.py
@@ -1,0 +1,26 @@
+"""
+Job creator - runs the GFF to JSON conversion script.
+"""
+
+from typing import TYPE_CHECKING
+
+from cpg_utils import Path, config, hail_batch
+
+if TYPE_CHECKING:
+    from hailtop.batch.job import BashJob
+
+
+def create_gff_conversion_job(output: Path) -> 'BashJob':
+    """Run the GFF to JSON conversion script."""
+    batch = hail_batch.get_batch()
+    job = batch.new_bash_job(name='Run GFF to JSON conversion script')
+    job.image(config.config_retrieve(['workflow', 'driver_image']))
+    job.storage('10GiB')
+
+    localised_gff = batch.read_input(config.config_retrieve(['references', 'ensembl_gff3']))
+
+    job.command(f'python -m cpg_flow_stripy.scripts.parse_gff_into_json --gff3 {localised_gff} --output {job.output}')
+
+    batch.write_output(job.output, output)
+
+    return job

--- a/src/cpg_flow_stripy/jobs/create_stripy_joint_call.py
+++ b/src/cpg_flow_stripy/jobs/create_stripy_joint_call.py
@@ -1,0 +1,38 @@
+"""
+Job creator - runs the STRipy JSONs to multisample VCF representation.
+"""
+
+from typing import TYPE_CHECKING
+
+from cpg_utils import Path, config, hail_batch
+
+if TYPE_CHECKING:
+    from hailtop.batch.job import BashJob
+
+
+def create_joint_call(json_paths: dict[str, Path], gene_lookup: Path, output: Path) -> 'BashJob':
+    """Run the GFF to JSON conversion script."""
+    batch = hail_batch.get_batch()
+    job = batch.new_bash_job(name='Run JSON to multisample VCF conversion')
+    job.image(config.config_retrieve(['workflow', 'driver_image']))
+    job.storage('10GiB')
+
+    localised_jsons = [batch.read_input(jpath) for jpath in json_paths.values()]
+
+    localised_mapping = batch.read_input(gene_lookup)
+
+    job.output.add_extension('.vcf.gz')
+
+    job.command(
+        f"""
+        python -m cpg_flow_stripy.scripts.stripy_to_vcf \\
+            --json {' '.join(localised_jsons)} \\
+            --output {job.output} \\
+            --mapping {localised_mapping}
+        """
+    )
+
+    # maybe tabix the file? that requires an extra tool added to the image and CBA right now
+    batch.write_output(job.output, output)
+
+    return job

--- a/src/cpg_flow_stripy/jobs/stripy.py
+++ b/src/cpg_flow_stripy/jobs/stripy.py
@@ -6,9 +6,10 @@ import json
 from typing import TYPE_CHECKING
 
 import loguru
+from metamist.graphql import gql, query
+
 from cpg_flow import targets
 from cpg_utils import Path, config, hail_batch, to_path
-from metamist.graphql import gql, query
 
 from cpg_flow_stripy.utils import get_loci_lists
 

--- a/src/cpg_flow_stripy/run_workflow.py
+++ b/src/cpg_flow_stripy/run_workflow.py
@@ -9,7 +9,7 @@ from argparse import ArgumentParser
 from cpg_flow.workflow import run_workflow
 from cpg_utils import hail_batch
 
-from cpg_flow_stripy.stages import MakeIndexPage
+from cpg_flow_stripy.stages import MakeIndexPage, MakeStripyJointCall
 
 
 def cli_main() -> None:
@@ -21,7 +21,7 @@ def cli_main() -> None:
     args = parser.parse_args()
     if not args.dry_run:
         hail_batch.get_batch(attributes={'stripy': 'true'})
-    run_workflow(name='stripy', stages=[MakeIndexPage], dry_run=args.dry_run)
+    run_workflow(name='stripy', stages=[MakeIndexPage, MakeStripyJointCall], dry_run=args.dry_run)
 
 
 if __name__ == '__main__':

--- a/src/cpg_flow_stripy/scripts/make_stripy_index.py
+++ b/src/cpg_flow_stripy/scripts/make_stripy_index.py
@@ -6,6 +6,7 @@ from importlib import resources
 from pathlib import Path
 
 import jinja2
+
 from cpg_utils import config
 
 

--- a/src/cpg_flow_stripy/scripts/parse_gff_into_json.py
+++ b/src/cpg_flow_stripy/scripts/parse_gff_into_json.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+
+"""
+Parses a GFF3 file, and generates a JSON file mapping Gene Symbols to Gene ID (ENSG)
+- chrom
+- start
+- end
+- gene details
+"""
+
+import gzip
+import json
+import re
+from argparse import ArgumentParser
+
+from cpg_utils import to_path
+
+CHROM_INDEX = 0
+RESOURCE_INDEX = 1
+TYPE_INDEX = 2
+START_INDEX = 3
+END_INDEX = 4
+DETAILS_INDEX = 8
+
+# regular expressions to parse out sections of the GFF3 annotations
+GENE_ID_RE = re.compile(r'gene:(ENSG\d+);')
+GENE_NAME_RE = re.compile(r'Name=([\w-]+);')
+
+TYPES_TO_KEEP: set[str] = {'gene', 'ncRNA_gene', 'snRNA'}
+
+CANONICAL_CONTIGS = [f'chr{x}' for x in list(range(1, 23))] + ['chrX', 'chrY', 'chrM']
+
+
+def main(gff3_file: str, output: str) -> None:
+    """
+    Read the GFF3 file, and generate a BED file of gene regions, plus padding
+    Args:
+        gff3_file (str): path to the GFF3 file
+        output (str): path to the JSON output file
+    """
+
+    gene_lookup = generate_gene_lookup(gff3_file)
+
+    with to_path(output).open('w') as output_handle:
+        json.dump(gene_lookup, output_handle, indent=4)
+
+
+def generate_gene_lookup(gff3_file: str) -> dict[str, str]:
+    """
+    Generate the new BED file, and return the lines as a list of lists for merging.
+    """
+
+    output_json: dict[str, str] = {}
+
+    # open and iterate over the GFF3 file
+    with gzip.open(gff3_file, 'rt') as handle:
+        for line in handle:
+            # skip over headers and dividing lines
+            if line.startswith('#'):
+                continue
+
+            line_as_list = line.rstrip().split('\t')
+
+            # skip over non-genes (e.g. pseudogenes, ncRNA). Only focus on Ensembl genes/transcripts
+            if (
+                line_as_list[TYPE_INDEX] not in TYPES_TO_KEEP
+                or 'ensembl' not in line_as_list[RESOURCE_INDEX]
+                or f'chr{line_as_list[CHROM_INDEX]}' not in CANONICAL_CONTIGS
+            ):
+                continue
+
+            # extract the gene name from the details field
+            # allowing for some situations that don't work,
+            # e.g. ENSG00000225931 (novel transcript, to be experimentally confirmed)
+            # search for ID and transcript separately, ordering not guaranteed
+            gene_name_match = GENE_NAME_RE.search(line_as_list[DETAILS_INDEX])
+            gene_id_match = GENE_ID_RE.search(line_as_list[DETAILS_INDEX])
+            if gene_id_match and gene_name_match:
+                output_json[gene_name_match.group(1)] = gene_id_match.group(1)
+            else:
+                print(f'Failed to extract gene name from {line_as_list[DETAILS_INDEX]}')
+    return output_json
+
+
+def cli_main() -> None:
+    parser = ArgumentParser()
+    parser.add_argument('--gff3', help='Path to the compressed GFF3 file', required=True)
+    parser.add_argument('--output', help='Path to output JSON.', required=True)
+    args = parser.parse_args()
+    main(gff3_file=args.gff3, output=args.output)
+
+
+if __name__ == '__main__':
+    cli_main()

--- a/src/cpg_flow_stripy/scripts/parse_gff_into_json.py
+++ b/src/cpg_flow_stripy/scripts/parse_gff_into_json.py
@@ -6,10 +6,14 @@ Parses a GFF3 file, and generates a JSON file mapping Gene Symbols to Gene ID (E
 - start
 - end
 - gene details
+
+This is built for and tested on the ensembl GFF file, though should generally work on valid GFF3 format files
+https://ftp.ensembl.org/pub/release-116/vertebrates/gff3/homo_sapiens/Homo_sapiens.GRCh38.116.chr.gff3.gz
 """
 
 import gzip
 import json
+import logging
 import re
 from argparse import ArgumentParser
 
@@ -78,7 +82,7 @@ def generate_gene_lookup(gff3_file: str) -> dict[str, str]:
             if gene_id_match and gene_name_match:
                 output_json[gene_name_match.group(1)] = gene_id_match.group(1)
             else:
-                print(f'Failed to extract gene name from {line_as_list[DETAILS_INDEX]}')
+                logging.debug(f'Failed to extract gene name from {line_as_list[DETAILS_INDEX]}')
     return output_json
 
 
@@ -87,6 +91,9 @@ def cli_main() -> None:
     parser.add_argument('--gff3', help='Path to the compressed GFF3 file', required=True)
     parser.add_argument('--output', help='Path to output JSON.', required=True)
     args = parser.parse_args()
+
+    logging.basicConfig(level=logging.INFO)
+
     main(gff3_file=args.gff3, output=args.output)
 
 

--- a/src/cpg_flow_stripy/scripts/stripy_to_vcf.py
+++ b/src/cpg_flow_stripy/scripts/stripy_to_vcf.py
@@ -1,217 +1,293 @@
 #!/usr/bin/env python3
 
+"""
+Borrowing _heavily_ from https://github.com/broadinstitute/gatk-sv/blob/7eb2af1feea9f81a390caff211f6832c6e7f7ac5/src/stripy/stripy_to_vcf.py
+Has been extended to take multiple single-sample STRipy reports as input, and to characterise the GT field as:
+- '0/0' 2 called alleles, no pathogenic
+- '1/0' a1 pathogenic, a2 non-pathogenic
+- '1/.' a1 pathogenic, a2 missing
+
+Uses fixed contigs (GRCh38) for the header, instead of relying on a reference input
+"""
+
 import argparse
 import json
 import re
 from pathlib import Path
 
 import pysam
-from pyfaidx import Fasta
+
+from cpg_utils import to_path
+
+CONTIG_ORDER = [f'chr{x}' for x in list(range(1, 23))] + ['chrX', 'chrY', 'chrM', 'chrMT']
+HEADER_LINES = [
+    ('chr1', 248956422),
+    ('chr2', 242193529),
+    ('chr3', 198295559),
+    ('chr4', 190214555),
+    ('chr5', 181538259),
+    ('chr6', 170805979),
+    ('chr7', 159345973),
+    ('chr8', 145138636),
+    ('chr9', 138394717),
+    ('chr10', 133797422),
+    ('chr11', 135086622),
+    ('chr12', 133275309),
+    ('chr13', 114364328),
+    ('chr14', 107043718),
+    ('chr15', 101991189),
+    ('chr16', 90338345),
+    ('chr17', 83257441),
+    ('chr18', 80373285),
+    ('chr19', 58617616),
+    ('chr20', 64444167),
+    ('chr21', 46709983),
+    ('chr22', 50818468),
+    ('chrX', 156040895),
+    ('chrY', 57227415),
+    ('chrM', 16569),
+]
 
 
-def parse_coords(coord):
-    m = re.match(r"(chr)?(?P<chrom>[^:]+):(?P<start>\d+)-(?P<end>\d+)", str(coord))
+def parse_coords(coord: str) -> tuple[str, int, int] | None:
+    m = re.match(r'(chr)?(?P<chrom>[^:]+):(?P<start>\d+)-(?P<end>\d+)', str(coord))
     if not m:
         return None
-    chrom = m.group("chrom")
-    if not chrom.startswith("chr"):
-        chrom = "chr" + chrom
-    return chrom, int(m.group("start")), int(m.group("end"))
+    chrom = m.group('chrom')
+    if not chrom.startswith('chr'):
+        chrom = 'chr' + chrom
+    return chrom, int(m.group('start')), int(m.group('end'))
 
 
-def chrom_key(c):
-    m = re.match(r"chr(\d+)$", c)
-    if m:
-        return (0, int(m.group(1)))
-    order = {"chrX": (1, 23), "chrY": (1, 24), "chrM": (2, 25), "chrMT": (2, 25)}
-    return order.get(c, (9, c))
-
-
-def _to_float(x):
+def _to_float(x: str | float) -> float:
     try:
         return float(x)
     except (TypeError, ValueError):
-        return float("nan")
+        return float('nan')
 
 
-def _to_outlier(x):
+def _to_outlier(x: str | int) -> int | None:
     try:
         return int(x)
     except (TypeError, ValueError):
         return None
 
 
-def _ci_tuple(allele):
-    return (allele["CI"].get("Min", 0), allele["CI"].get("Max", 0))
+def _ci_tuple(allele: dict[str, dict[str, int]]) -> tuple[int, int]:
+    return allele['CI'].get('Min', 0), allele['CI'].get('Max', 0)
 
 
-def load_sample(json_path, sample_name_override=None):
+def load_sample(json_path: str, sample_name_override: str | None = None) -> tuple[str, dict]:
     """Load a STRipy JSON and return (sample_name, loci_dict keyed by locus_id)."""
-    with open(json_path) as f:
+    with to_path(json_path).open() as f:
         data = json.load(f)
 
     if sample_name_override:
         sample_name = sample_name_override
     else:
-        input_file = data.get("JobDetails", {}).get("InputFile", "")
+        input_file = data.get('JobDetails', {}).get('InputFile', '')
         if input_file:
             stem = Path(input_file).stem
-            sample_name = stem.split("__")[0]
+            sample_name = stem.split('__')[0]
         else:
-            sample_name = Path(json_path).stem.split(".")[0]
+            sample_name = Path(json_path).stem.split('.')[0]
 
     loci = {}
-    for entry in data.get("GenotypingResults", []):
+    for entry in data.get('GenotypingResults', []):
         for locus_name, locus in entry.items():
-            tl = locus["TargetedLocus"]
-            parsed = parse_coords(tl["Coordinates"])
+            tl = locus['TargetedLocus']
+            parsed = parse_coords(tl['Coordinates'])
             if not parsed:
                 continue
             chrom, start, end = parsed
-            alleles = locus["Alleles"]
+            alleles = locus['Alleles']
             a1 = alleles[0]
             a2 = alleles[1] if len(alleles) > 1 else None
-            locus_id = str(tl.get("LocusID") or locus_name)
-            motif = tl["Motif"]
+            locus_id = str(tl.get('LocusID') or locus_name)
+            motif = tl['Motif']
             loci[locus_id] = {
-                "chrom": chrom,
-                "pos": start,
-                "end": end,
-                "id": locus_id,
-                "motif": motif,
-                "period": len(motif),
-                "a1_rep": _to_float(a1["Repeats"]),
-                "a2_rep": _to_float(a2["Repeats"]) if a2 is not None else None,
-                "a1_ci": _ci_tuple(a1),
-                "a2_ci": _ci_tuple(a2) if a2 is not None else (0, 0),
-                "a1_out": _to_outlier(a1["IsPopulationOutlier"]),
-                "a2_out": _to_outlier(a2["IsPopulationOutlier"]) if a2 is not None else None,
-                "a1_z": _to_float(a1["PopulationZscore"]),
-                "a2_z": _to_float(a2["PopulationZscore"]) if a2 is not None else None,
-                "coverage": locus["Metadata"]["Coverage"],
-                "filter": locus["Filter"],
-                "diseases": "|".join(sorted({meta["DiseaseSymbol"] for meta in tl["CorrespondingDisease"].values()})),
+                'chrom': chrom,
+                'pos': start,
+                'end': end,
+                'id': locus_id,
+                'motif': motif,
+                'period': len(motif),
+                'a1_rep': _to_float(a1['Repeats']),
+                'a2_rep': _to_float(a2['Repeats']) if a2 is not None else None,
+                'a1_ci': _ci_tuple(a1),
+                'a2_ci': _ci_tuple(a2) if a2 is not None else (0, 0),
+                'a1_range': a1['Range'],
+                'a2_range': a2['Range'] if a2 else None,
+                'a1_out': _to_outlier(a1['IsPopulationOutlier']),
+                'a2_out': _to_outlier(a2['IsPopulationOutlier']) if a2 is not None else None,
+                'a1_z': _to_float(a1['PopulationZscore']),
+                'a2_z': _to_float(a2['PopulationZscore']) if a2 is not None else None,
+                'coverage': locus['Metadata']['Coverage'],
+                'filter': locus['Filter'],
+                'diseases': '|'.join(sorted({meta['DiseaseSymbol'] for meta in tl['CorrespondingDisease'].values()})),
             }
 
     return sample_name, loci
 
 
 VCF_HEADER = {
-    "INFO": [
-        {"ID": "END", "Number": "1", "Type": "Integer", "Description": "Stop position of the interval"},
-        {"ID": "SVTYPE", "Number": "1", "Type": "String", "Description": "Type of structural variant"},
-        {"ID": "RU", "Number": "1", "Type": "String", "Description": "Repeat unit in the reference orientation"},
-        {"ID": "PERIOD", "Number": "1", "Type": "Integer", "Description": "Length of the repeat unit"},
-        {"ID": "DISEASES", "Number": ".", "Type": "String", "Description": "Associated disease symbols for this locus (| separated)"},
-        {"ID": "LOCUS", "Number": "1", "Type": "String", "Description": "Gene/locus identifier from STRipy"},
+    'INFO': [
+        {'ID': 'END', 'Number': '1', 'Type': 'Integer', 'Description': 'Stop position of the interval'},
+        {'ID': 'SVTYPE', 'Number': '1', 'Type': 'String', 'Description': 'Type of structural variant'},
+        {'ID': 'RU', 'Number': '1', 'Type': 'String', 'Description': 'Repeat unit in the reference orientation'},
+        {'ID': 'PERIOD', 'Number': '1', 'Type': 'Integer', 'Description': 'Length of the repeat unit'},
+        {
+            'ID': 'DISEASES',
+            'Number': '.',
+            'Type': 'String',
+            'Description': 'Associated disease symbols for this locus (| separated)',
+        },
+        {'ID': 'LOCUS', 'Number': '1', 'Type': 'String', 'Description': 'Gene/locus identifier from STRipy'},
+        {'ID': 'GENE', 'Number': '1', 'Type': 'String', 'Description': 'Gene inferred from STRipy locus identifier'},
     ],
-    "FORMAT": [
-        {"ID": "GT", "Number": "1", "Type": "String", "Description": "Unphased genotype"},
-        {"ID": "REPCN", "Number": "2", "Type": "Float", "Description": "Number of repeat units spanned by each allele"},
-        {"ID": "REPCI1", "Number": "2", "Type": "Integer", "Description": "95% CI min,max on repeat counts of first allele"},
-        {"ID": "REPCI2", "Number": "2", "Type": "Integer", "Description": "95% CI min,max on repeat counts of second allele"},
-        {"ID": "OUTLIER", "Number": "2", "Type": "Integer", "Description": "Allelic population outlier flags (0/1) assigned by STRipy"},
-        {"ID": "ZSCORE", "Number": "2", "Type": "Float", "Description": "Allelic population Z-scores assigned by STRipy"},
-        {"ID": "DP", "Number": "1", "Type": "Integer", "Description": "Total Depth"},
-        {"ID": "STR_FILTER", "Number": ".", "Type": "String", "Description": "Filter status assigned by STRipy"},
+    'FORMAT': [
+        {'ID': 'GT', 'Number': '1', 'Type': 'String', 'Description': 'Unphased genotype'},
+        {'ID': 'REPCN', 'Number': '2', 'Type': 'Float', 'Description': 'Number of repeat units spanned by each allele'},
+        {
+            'ID': 'REPCI1',
+            'Number': '2',
+            'Type': 'Integer',
+            'Description': '95% CI min,max on repeat counts of first allele',
+        },
+        {
+            'ID': 'REPCI2',
+            'Number': '2',
+            'Type': 'Integer',
+            'Description': '95% CI min,max on repeat counts of second allele',
+        },
+        {
+            'ID': 'OUTLIER',
+            'Number': '2',
+            'Type': 'Integer',
+            'Description': 'Allelic population outlier flags (0/1) assigned by STRipy',
+        },
+        {
+            'ID': 'ZSCORE',
+            'Number': '2',
+            'Type': 'Float',
+            'Description': 'Allelic population Z-scores assigned by STRipy',
+        },
+        {'ID': 'DP', 'Number': '1', 'Type': 'Integer', 'Description': 'Total Depth'},
+        {'ID': 'STR_FILTER', 'Number': '.', 'Type': 'String', 'Description': 'Filter status assigned by STRipy'},
     ],
 }
 
 
-def write_multisample_vcf(samples, out_path, contigs=None):
+def get_header(sample_names: list[str]) -> pysam.VariantHeader:
+    """Fill the header."""
+    header = pysam.VariantHeader()
+    header.add_meta('source', value='STRipy2VCF')
+    header.add_meta('ALT', items=[('ID', 'STR'), ('Description', 'Short tandem repeat')])
+    for info in VCF_HEADER['INFO']:
+        header.add_meta('INFO', items=list(info.items()))
+    for fmt in VCF_HEADER['FORMAT']:
+        header.add_meta('FORMAT', items=list(fmt.items()))
+
+    # generate the contig header lines
+    for contig, length in HEADER_LINES:
+        header.contigs.add(contig, length=length)
+
+    for sample_name in sample_names:
+        header.add_sample(sample_name)
+
+    return header
+
+
+def write_multisample_vcf(samples: list[tuple[str, dict[str, dict]]], out_path: str) -> None:
     """
     samples: list of (sample_name, loci_dict) tuples
     loci_dict: dict keyed by locus_id -> locus data
     """
-    header = pysam.VariantHeader()
-    header.add_meta("source", value="STRipy2VCF")
-    header.add_meta("ALT", items=[("ID", "STR"), ("Description", "Short tandem repeat")])
-    for info in VCF_HEADER["INFO"]:
-        header.add_meta("INFO", items=list(info.items()))
-    for fmt in VCF_HEADER["FORMAT"]:
-        header.add_meta("FORMAT", items=list(fmt.items()))
 
-    canonical = {}
+    header = get_header(sample_names=[sam_bit[0] for sam_bit in samples])
+
+    canonical: dict[str, dict] = {}
     for _, loci in samples:
         for locus_id, loc in loci.items():
             canonical.setdefault(locus_id, loc)
 
-    sorted_loci = sorted(canonical.values(), key=lambda x: (chrom_key(x["chrom"]), x["pos"]))
+    # double sort contigs by both chrom and position
+    sorted_loci = sorted(canonical.values(), key=lambda x: (CONTIG_ORDER.index(x['chrom']), x['pos']))
 
-    if contigs is not None:
-        for name, length in contigs:
-            header.contigs.add(name, length=length)
-    else:
-        for chrom_name in dict.fromkeys(loc["chrom"] for loc in sorted_loci):
-            header.contigs.add(chrom_name)
-
-    for sample_name, _ in samples:
-        header.add_sample(sample_name)
-
-    with pysam.VariantFile(out_path, mode="w", header=header) as vf:
+    with pysam.VariantFile(out_path, mode='w', header=header) as vf:
         for loc in sorted_loci:
             rec = header.new_record()
-            rec.contig = loc["chrom"]
-            rec.start = loc["pos"] - 1
-            rec.stop = loc["end"]
-            rec.id = str(loc["id"])
-            rec.ref = "N"
-            rec.alts = ("<STR>",)
-            rec.filter.add(loc["filter"] if loc["filter"] else "PASS")
-            rec.info["SVTYPE"] = "STR"
-            if loc["motif"]:
-                rec.info["RU"] = loc["motif"]
-            if loc["period"]:
-                rec.info["PERIOD"] = int(loc["period"])
-            rec.info["DISEASES"] = loc["diseases"]
-            rec.info["LOCUS"] = loc["id"]
+            rec.contig = loc['chrom']
+            rec.start = loc['pos'] - 1
+            rec.stop = loc['end']
+            rec.id = str(loc['id'])
+            rec.ref = 'N'
+            rec.alts = ('<STR>',)
+            rec.filter.add(loc['filter'] if loc['filter'] else 'PASS')
+            rec.info['SVTYPE'] = 'STR'
+            if loc['motif']:
+                rec.info['RU'] = loc['motif']
+            if loc['period']:
+                rec.info['PERIOD'] = int(loc['period'])
+            rec.info['DISEASES'] = loc['diseases']
+            rec.info['LOCUS'] = loc['id']
+            rec.info['GENE'] = loc['id'].split('_')[0]
 
             for sample_name, loci in samples:
-                s_loc = loci.get(loc["id"])
+                s_loc = loci.get(loc['id'])
                 s = rec.samples[sample_name]
-                s["GT"] = (".", ".")
                 if s_loc is None:
-                    s["REPCN"] = (None, None)
-                    s["REPCI1"] = (0, 0)
-                    s["REPCI2"] = (0, 0)
-                    s["OUTLIER"] = (None, None)
-                    s["ZSCORE"] = (None, None)
-                    s["DP"] = None
-                    s["STR_FILTER"] = ["."]
+                    s['REPCN'] = (None, None)
+                    s['REPCI1'] = (0, 0)
+                    s['REPCI2'] = (0, 0)
+                    s['OUTLIER'] = (None, None)
+                    s['ZSCORE'] = (None, None)
+                    s['DP'] = None
+                    s['STR_FILTER'] = ['.']
                 else:
-                    s["REPCN"] = (s_loc["a1_rep"], s_loc["a2_rep"])
-                    s["REPCI1"] = s_loc["a1_ci"]
-                    s["REPCI2"] = s_loc["a2_ci"]
-                    s["OUTLIER"] = (s_loc["a1_out"], s_loc["a2_out"])
-                    s["ZSCORE"] = (s_loc["a1_z"], s_loc["a2_z"])
-                    s["DP"] = int(s_loc["coverage"])
-                    s["STR_FILTER"] = [str(s_loc["filter"])] if s_loc["filter"] else ["PASS"]
+                    if s_loc['a2_range'].lower() == 'pathogenic':
+                        a2 = 1
+                    elif s_loc['a2_range'] is None:
+                        a2 = None
+                    else:
+                        a2 = 0
+                    s['GT'] = (
+                        1 if s_loc['a1_range'].lower() == 'pathogenic' else 0,
+                        a2,
+                    )
+                    s['REPCN'] = (s_loc['a1_rep'], s_loc['a2_rep'])
+                    s['REPCI1'] = s_loc['a1_ci']
+                    s['REPCI2'] = s_loc['a2_ci']
+                    s['OUTLIER'] = (s_loc['a1_out'], s_loc['a2_out'])
+                    s['ZSCORE'] = (s_loc['a1_z'], s_loc['a2_z'])
+                    s['DP'] = int(s_loc['coverage'])
+                    s['STR_FILTER'] = [str(s_loc['filter'])] if s_loc['filter'] else ['PASS']
 
             vf.write(rec)
 
 
-def main():
-    ap = argparse.ArgumentParser(description="Convert STRipy JSON output(s) into a multi-sample VCF with SV-style STR annotations.")
-    ap.add_argument("--json", required=True, nargs="+", help="STRipy JSON report(s); one per sample")
-    ap.add_argument("-o", "--out", required=True, help="Output VCF")
-    ap.add_argument("--sample-names", nargs="+", default=None, help="Sample names (must match number of --json files if provided; defaults to ID extracted from JobDetails.InputFile)")
-    ap.add_argument("--reference", default=None, help="Optional reference FASTA for contig lengths")
+def main() -> None:
+    ap = argparse.ArgumentParser(
+        description='Convert STRipy JSON output(s) into a multi-sample VCF with SV-style STR annotations.'
+    )
+    ap.add_argument('--json', required=True, nargs='+', help='STRipy JSON report(s); one per sample')
+    ap.add_argument('-o', '--out', required=True, help='Output VCF')
+    ap.add_argument(
+        '--sample-names',
+        nargs='+',
+        default=None,
+        help='Sample names (must match number of --json files if provided; defaults to ID extracted from JSON)',
+    )
     args = ap.parse_args()
 
     if args.sample_names and len(args.sample_names) != len(args.json):
-        ap.error(f"--sample-names count ({len(args.sample_names)}) must match --json count ({len(args.json)})")
+        ap.error(f'--sample-names count ({len(args.sample_names)}) must match --json count ({len(args.json)})')
 
     overrides = args.sample_names or [None] * len(args.json)
-    samples = [load_sample(p, name) for p, name in zip(args.json, overrides)]
+    samples = [load_sample(p, name) for p, name in zip(args.json, overrides, strict=True)]
 
-    contigs = None
-    if args.reference:
-        reference = Fasta(args.reference, as_raw=True, read_ahead=1000000)
-        contigs = [(name, len(reference[name])) for name in reference.keys()]
-        reference.close()
-
-    write_multisample_vcf(samples, args.out, contigs=contigs)
+    write_multisample_vcf(samples, args.out)
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     main()

--- a/src/cpg_flow_stripy/scripts/stripy_to_vcf.py
+++ b/src/cpg_flow_stripy/scripts/stripy_to_vcf.py
@@ -121,7 +121,7 @@ def load_sample(json_path: str) -> tuple[str, dict]:
                 'a1_rep': _to_float(a1['Repeats']),
                 'a2_rep': _to_float(a2['Repeats']) if a2 is not None else None,
                 'a1_ci': _ci_tuple(a1),
-                'a2_ci': _ci_tuple(a2) if a2 is not None else (0, 0),
+                'a2_ci': _ci_tuple(a2) if a2 is not None else (None, None),
                 'a1_range': a1['Range'],
                 'a2_range': a2['Range'] if a2 else None,
                 'a1_out': _to_outlier(a1['IsPopulationOutlier']),
@@ -282,8 +282,8 @@ def write_multisample_vcf(
                 if s_loc is None:
                     s['GT'] = (None, None)
                     s['REPCN'] = (None, None)
-                    s['REPCI1'] = (0, 0)
-                    s['REPCI2'] = (0, 0)
+                    s['REPCI1'] = (None, None)
+                    s['REPCI2'] = (None, None)
                     s['OUTLIER'] = (None, None)
                     s['ZSCORE'] = (None, None)
                     s['DP'] = None

--- a/src/cpg_flow_stripy/scripts/stripy_to_vcf.py
+++ b/src/cpg_flow_stripy/scripts/stripy_to_vcf.py
@@ -12,6 +12,7 @@ Uses fixed contigs (GRCh38) for the header, instead of relying on a reference in
 
 import argparse
 import json
+import logging
 import re
 from pathlib import Path
 
@@ -102,11 +103,16 @@ def load_sample(json_path: str) -> tuple[str, dict]:
     loci = {}
     for entry in data.get('GenotypingResults', []):
         for locus_name, locus in entry.items():
+            tl = locus['TargetedLocus']
+
             # add flexibility if the Alleles aren't populated at all
             if 'Alleles' not in locus:
+                explain_string = f'Parsing {sample_name}, locus {tl["LocusID"]}, no Alleles present - skipping. '
+                if 'Filter' in locus:
+                    explain_string += f'Filter: {locus["Filter"]} - '
+                logging.warning(explain_string)
                 continue
 
-            tl = locus['TargetedLocus']
             parsed = parse_coords(tl['Coordinates'])
             if not parsed:
                 continue

--- a/src/cpg_flow_stripy/scripts/stripy_to_vcf.py
+++ b/src/cpg_flow_stripy/scripts/stripy_to_vcf.py
@@ -102,6 +102,10 @@ def load_sample(json_path: str) -> tuple[str, dict]:
     loci = {}
     for entry in data.get('GenotypingResults', []):
         for locus_name, locus in entry.items():
+            # add flexibility if the Alleles aren't populated at all
+            if 'Alleles' not in locus:
+                continue
+
             tl = locus['TargetedLocus']
             parsed = parse_coords(tl['Coordinates'])
             if not parsed:

--- a/src/cpg_flow_stripy/scripts/stripy_to_vcf.py
+++ b/src/cpg_flow_stripy/scripts/stripy_to_vcf.py
@@ -91,7 +91,7 @@ def load_sample(json_path: str) -> tuple[str, dict]:
     with to_path(json_path).open() as f:
         data = json.load(f)
 
-    # hard wired to pull the SampleID from the input filename - consider reverting
+    # hard-wired to pull the SampleID from the input filename - consider reverting
     input_file = data.get('JobDetails', {}).get('InputFile', '')
     if input_file:
         stem = Path(input_file).stem
@@ -149,7 +149,8 @@ VCF_HEADER = {
             'Description': 'Associated disease symbols for this locus (| separated)',
         },
         {'ID': 'LOCUS', 'Number': '1', 'Type': 'String', 'Description': 'Gene/locus identifier from STRipy'},
-        {'ID': 'GENE', 'Number': '1', 'Type': 'String', 'Description': 'Gene inferred from STRipy locus identifier'},
+        {'ID': 'SYMBOL', 'Number': '1', 'Type': 'String', 'Description': 'Gene inferred from STRipy locus identifier'},
+        {'ID': 'GENE', 'Number': '1', 'Type': 'String', 'Description': 'ENSG ID inferred from Gene Symbol'},
     ],
     'FORMAT': [
         {'ID': 'GT', 'Number': '1', 'Type': 'String', 'Description': 'Unphased genotype'},
@@ -213,17 +214,26 @@ def convert_range_to_gt(range_val: str | None) -> int | None:
     return 0
 
 
-def write_multisample_vcf(samples: list[tuple[str, dict[str, dict]]], out_path: str) -> None:
+def write_multisample_vcf(
+    samples: list[tuple[str, dict[str, dict]]], out_path: str, gene_map: str | None = None
+) -> None:
     """
-    samples: list of (sample_name, loci_dict) tuples
-    loci_dict: dict keyed by locus_id -> locus data
+    Integrate the per-sample data into a union VCF
+
+    Args:
+        samples: list of (sample_name, loci_dict) tuples
+        out_path: vcf path to write output to. PySam will write compressed if ending is gz/bgz
+        gene_map: optional, file path to a JSON dict, mapping gene symbols to gene IDs
     """
+
+    gene_lookup = json.load(open(gene_map)) if gene_map else {}
 
     header = get_header(sample_names=[sam_bit[0] for sam_bit in samples])
 
     only_loci = get_limited_locus_list()
 
     canonical: dict[str, dict] = {}
+
     for _, loci in samples:
         for locus_id, loc in loci.items():
             # if we got a list of specific loci, only use that finite list - ignore everything else
@@ -251,7 +261,11 @@ def write_multisample_vcf(samples: list[tuple[str, dict[str, dict]]], out_path: 
                 rec.info['PERIOD'] = int(loc['period'])
             rec.info['DISEASES'] = loc['diseases']
             rec.info['LOCUS'] = loc['id']
-            rec.info['GENE'] = loc['id'].split('_')[0]
+
+            # extract the gene symbol from STRipy annotations
+            symbol = loc['id'].split('_')[0]
+            rec.info['SYMBOL'] = symbol
+            rec.info['GENE'] = gene_lookup.get(symbol, symbol)
 
             for sample_name, loci in samples:
                 s_loc = loci.get(loc['id'])
@@ -279,15 +293,14 @@ def write_multisample_vcf(samples: list[tuple[str, dict[str, dict]]], out_path: 
 
 
 def main() -> None:
-    ap = argparse.ArgumentParser(
-        description='Convert STRipy JSON output(s) into a multi-sample VCF with SV-style STR annotations.'
-    )
+    ap = argparse.ArgumentParser(description='Convert STRipy JSON output(s) into a multi-sample VCF.')
     ap.add_argument('--json', required=True, nargs='+', help='STRipy JSON report(s); one per sample')
-    ap.add_argument('-o', '--out', required=True, help='Output VCF')
+    ap.add_argument('--out', required=True, help='Output VCF')
+    ap.add_argument('--dict', default=None, help='A JSON dict of Gene Symbol:Gene ID to update annotation')
     args = ap.parse_args()
     samples = [load_sample(p) for p in args.json]
 
-    write_multisample_vcf(samples, args.out)
+    write_multisample_vcf(samples, args.out, args.dict)
 
 
 if __name__ == '__main__':

--- a/src/cpg_flow_stripy/scripts/stripy_to_vcf.py
+++ b/src/cpg_flow_stripy/scripts/stripy_to_vcf.py
@@ -86,20 +86,18 @@ def _ci_tuple(allele: dict[str, dict[str, int]]) -> tuple[int, int]:
     return allele['CI'].get('Min', 0), allele['CI'].get('Max', 0)
 
 
-def load_sample(json_path: str, sample_name_override: str | None = None) -> tuple[str, dict]:
+def load_sample(json_path: str) -> tuple[str, dict]:
     """Load a STRipy JSON and return (sample_name, loci_dict keyed by locus_id)."""
     with to_path(json_path).open() as f:
         data = json.load(f)
 
-    if sample_name_override:
-        sample_name = sample_name_override
+    # hard wired to pull the SampleID from the input filename - consider reverting
+    input_file = data.get('JobDetails', {}).get('InputFile', '')
+    if input_file:
+        stem = Path(input_file).stem
+        sample_name = stem.split('__')[0]
     else:
-        input_file = data.get('JobDetails', {}).get('InputFile', '')
-        if input_file:
-            stem = Path(input_file).stem
-            sample_name = stem.split('__')[0]
-        else:
-            sample_name = Path(json_path).stem.split('.')[0]
+        sample_name = Path(json_path).stem.split('.')[0]
 
     loci = {}
     for entry in data.get('GenotypingResults', []):
@@ -286,19 +284,8 @@ def main() -> None:
     )
     ap.add_argument('--json', required=True, nargs='+', help='STRipy JSON report(s); one per sample')
     ap.add_argument('-o', '--out', required=True, help='Output VCF')
-    ap.add_argument(
-        '--sample-names',
-        nargs='+',
-        default=None,
-        help='Sample names (must match number of --json files if provided; defaults to ID extracted from JSON)',
-    )
     args = ap.parse_args()
-
-    if args.sample_names and len(args.sample_names) != len(args.json):
-        ap.error(f'--sample-names count ({len(args.sample_names)}) must match --json count ({len(args.json)})')
-
-    overrides = args.sample_names or [None] * len(args.json)
-    samples = [load_sample(p, name) for p, name in zip(args.json, overrides, strict=True)]
+    samples = [load_sample(p) for p in args.json]
 
     write_multisample_vcf(samples, args.out)
 

--- a/src/cpg_flow_stripy/scripts/stripy_to_vcf.py
+++ b/src/cpg_flow_stripy/scripts/stripy_to_vcf.py
@@ -262,7 +262,7 @@ def write_multisample_vcf(
             rec.id = str(loc['id'])
             rec.ref = 'N'
             rec.alts = ('<STR>',)
-            rec.filter.add(loc['filter'] if loc['filter'] else 'PASS')
+            rec.filter.add('PASS')
             rec.info['SVTYPE'] = 'STR'
             if loc['motif']:
                 rec.info['RU'] = loc['motif']

--- a/src/cpg_flow_stripy/scripts/stripy_to_vcf.py
+++ b/src/cpg_flow_stripy/scripts/stripy_to_vcf.py
@@ -214,6 +214,15 @@ def convert_range_to_gt(range_val: str | None) -> int | None:
     return 0
 
 
+def get_gene_lookup(map_path: str | None = None) -> dict[str, str]:
+    """Pull out the dictionary reading logic."""
+    lookup: dict[str, str] = {}
+    if map_path is not None:
+        with to_path(map_path).open() as handle:
+            lookup = json.load(handle)
+    return lookup
+
+
 def write_multisample_vcf(
     samples: list[tuple[str, dict[str, dict]]], out_path: str, gene_map: str | None = None
 ) -> None:
@@ -226,7 +235,7 @@ def write_multisample_vcf(
         gene_map: optional, file path to a JSON dict, mapping gene symbols to gene IDs
     """
 
-    gene_lookup = json.load(open(gene_map)) if gene_map else {}
+    gene_lookup = get_gene_lookup(gene_map)
 
     header = get_header(sample_names=[sam_bit[0] for sam_bit in samples])
 
@@ -295,12 +304,13 @@ def write_multisample_vcf(
 def main() -> None:
     ap = argparse.ArgumentParser(description='Convert STRipy JSON output(s) into a multi-sample VCF.')
     ap.add_argument('--json', required=True, nargs='+', help='STRipy JSON report(s); one per sample')
-    ap.add_argument('--out', required=True, help='Output VCF')
-    ap.add_argument('--dict', default=None, help='A JSON dict of Gene Symbol:Gene ID to update annotation')
+    ap.add_argument('--output', required=True, help='Output VCF')
+    ap.add_argument('--mapping', default=None, help='A JSON dict of Gene Symbol:Gene ID to update annotation')
     args = ap.parse_args()
+
     samples = [load_sample(p) for p in args.json]
 
-    write_multisample_vcf(samples, args.out, args.dict)
+    write_multisample_vcf(samples=samples, out_path=args.output, gene_map=args.mapping)
 
 
 if __name__ == '__main__':

--- a/src/cpg_flow_stripy/scripts/stripy_to_vcf.py
+++ b/src/cpg_flow_stripy/scripts/stripy_to_vcf.py
@@ -17,7 +17,7 @@ from pathlib import Path
 
 import pysam
 
-from cpg_utils import to_path
+from cpg_utils import config, to_path
 
 CONTIG_ORDER = [f'chr{x}' for x in list(range(1, 23))] + ['chrX', 'chrY', 'chrM', 'chrMT']
 HEADER_LINES = [
@@ -47,6 +47,15 @@ HEADER_LINES = [
     ('chrY', 57227415),
     ('chrM', 16569),
 ]
+
+
+def get_limited_locus_list() -> list[str] | None:
+    """Try to get the finite list of loci from config, if available."""
+    try:
+        return config.config_retrieve(['stripy', 'loci_lists', 'default_with_exclusions'])
+    except config.ConfigError:
+        print('No CPG config detected, using all loci')
+        return None
 
 
 def parse_coords(coord: str) -> tuple[str, int, int] | None:
@@ -103,13 +112,12 @@ def load_sample(json_path: str, sample_name_override: str | None = None) -> tupl
             alleles = locus['Alleles']
             a1 = alleles[0]
             a2 = alleles[1] if len(alleles) > 1 else None
-            locus_id = str(tl.get('LocusID') or locus_name)
             motif = tl['Motif']
-            loci[locus_id] = {
+            loci[locus_name] = {
                 'chrom': chrom,
                 'pos': start,
                 'end': end,
-                'id': locus_id,
+                'id': locus_name,
                 'motif': motif,
                 'period': len(motif),
                 'a1_rep': _to_float(a1['Repeats']),
@@ -198,6 +206,15 @@ def get_header(sample_names: list[str]) -> pysam.VariantHeader:
     return header
 
 
+def convert_range_to_gt(range_val: str | None) -> int | None:
+    """Converts the per-allele range to an integer, for embedding in GT."""
+    if range_val is None:
+        return None
+    if range_val.lower() == 'pathogenic':
+        return 1
+    return 0
+
+
 def write_multisample_vcf(samples: list[tuple[str, dict[str, dict]]], out_path: str) -> None:
     """
     samples: list of (sample_name, loci_dict) tuples
@@ -206,9 +223,14 @@ def write_multisample_vcf(samples: list[tuple[str, dict[str, dict]]], out_path: 
 
     header = get_header(sample_names=[sam_bit[0] for sam_bit in samples])
 
+    only_loci = get_limited_locus_list()
+
     canonical: dict[str, dict] = {}
     for _, loci in samples:
         for locus_id, loc in loci.items():
+            # if we got a list of specific loci, only use that finite list - ignore everything else
+            if (only_loci is not None) and (locus_id not in only_loci):
+                continue
             canonical.setdefault(locus_id, loc)
 
     # double sort contigs by both chrom and position
@@ -237,6 +259,7 @@ def write_multisample_vcf(samples: list[tuple[str, dict[str, dict]]], out_path: 
                 s_loc = loci.get(loc['id'])
                 s = rec.samples[sample_name]
                 if s_loc is None:
+                    s['GT'] = (None, None)
                     s['REPCN'] = (None, None)
                     s['REPCI1'] = (0, 0)
                     s['REPCI2'] = (0, 0)
@@ -245,16 +268,7 @@ def write_multisample_vcf(samples: list[tuple[str, dict[str, dict]]], out_path: 
                     s['DP'] = None
                     s['STR_FILTER'] = ['.']
                 else:
-                    if s_loc['a2_range'].lower() == 'pathogenic':
-                        a2 = 1
-                    elif s_loc['a2_range'] is None:
-                        a2 = None
-                    else:
-                        a2 = 0
-                    s['GT'] = (
-                        1 if s_loc['a1_range'].lower() == 'pathogenic' else 0,
-                        a2,
-                    )
+                    s['GT'] = (convert_range_to_gt(s_loc['a1_range']), convert_range_to_gt(s_loc['a2_range']))
                     s['REPCN'] = (s_loc['a1_rep'], s_loc['a2_rep'])
                     s['REPCI1'] = s_loc['a1_ci']
                     s['REPCI2'] = s_loc['a2_ci']

--- a/src/cpg_flow_stripy/scripts/stripy_to_vcf.py
+++ b/src/cpg_flow_stripy/scripts/stripy_to_vcf.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import re
+from pathlib import Path
+
+import pysam
+from pyfaidx import Fasta
+
+
+def parse_coords(coord):
+    m = re.match(r"(chr)?(?P<chrom>[^:]+):(?P<start>\d+)-(?P<end>\d+)", str(coord))
+    if not m:
+        return None
+    chrom = m.group("chrom")
+    if not chrom.startswith("chr"):
+        chrom = "chr" + chrom
+    return chrom, int(m.group("start")), int(m.group("end"))
+
+
+def chrom_key(c):
+    m = re.match(r"chr(\d+)$", c)
+    if m:
+        return (0, int(m.group(1)))
+    order = {"chrX": (1, 23), "chrY": (1, 24), "chrM": (2, 25), "chrMT": (2, 25)}
+    return order.get(c, (9, c))
+
+
+def _to_float(x):
+    try:
+        return float(x)
+    except (TypeError, ValueError):
+        return float("nan")
+
+
+def _to_outlier(x):
+    try:
+        return int(x)
+    except (TypeError, ValueError):
+        return None
+
+
+def _ci_tuple(allele):
+    return (allele["CI"].get("Min", 0), allele["CI"].get("Max", 0))
+
+
+def load_sample(json_path, sample_name_override=None):
+    """Load a STRipy JSON and return (sample_name, loci_dict keyed by locus_id)."""
+    with open(json_path) as f:
+        data = json.load(f)
+
+    if sample_name_override:
+        sample_name = sample_name_override
+    else:
+        input_file = data.get("JobDetails", {}).get("InputFile", "")
+        if input_file:
+            stem = Path(input_file).stem
+            sample_name = stem.split("__")[0]
+        else:
+            sample_name = Path(json_path).stem.split(".")[0]
+
+    loci = {}
+    for entry in data.get("GenotypingResults", []):
+        for locus_name, locus in entry.items():
+            tl = locus["TargetedLocus"]
+            parsed = parse_coords(tl["Coordinates"])
+            if not parsed:
+                continue
+            chrom, start, end = parsed
+            alleles = locus["Alleles"]
+            a1 = alleles[0]
+            a2 = alleles[1] if len(alleles) > 1 else None
+            locus_id = str(tl.get("LocusID") or locus_name)
+            motif = tl["Motif"]
+            loci[locus_id] = {
+                "chrom": chrom,
+                "pos": start,
+                "end": end,
+                "id": locus_id,
+                "motif": motif,
+                "period": len(motif),
+                "a1_rep": _to_float(a1["Repeats"]),
+                "a2_rep": _to_float(a2["Repeats"]) if a2 is not None else None,
+                "a1_ci": _ci_tuple(a1),
+                "a2_ci": _ci_tuple(a2) if a2 is not None else (0, 0),
+                "a1_out": _to_outlier(a1["IsPopulationOutlier"]),
+                "a2_out": _to_outlier(a2["IsPopulationOutlier"]) if a2 is not None else None,
+                "a1_z": _to_float(a1["PopulationZscore"]),
+                "a2_z": _to_float(a2["PopulationZscore"]) if a2 is not None else None,
+                "coverage": locus["Metadata"]["Coverage"],
+                "filter": locus["Filter"],
+                "diseases": "|".join(sorted({meta["DiseaseSymbol"] for meta in tl["CorrespondingDisease"].values()})),
+            }
+
+    return sample_name, loci
+
+
+VCF_HEADER = {
+    "INFO": [
+        {"ID": "END", "Number": "1", "Type": "Integer", "Description": "Stop position of the interval"},
+        {"ID": "SVTYPE", "Number": "1", "Type": "String", "Description": "Type of structural variant"},
+        {"ID": "RU", "Number": "1", "Type": "String", "Description": "Repeat unit in the reference orientation"},
+        {"ID": "PERIOD", "Number": "1", "Type": "Integer", "Description": "Length of the repeat unit"},
+        {"ID": "DISEASES", "Number": ".", "Type": "String", "Description": "Associated disease symbols for this locus (| separated)"},
+        {"ID": "LOCUS", "Number": "1", "Type": "String", "Description": "Gene/locus identifier from STRipy"},
+    ],
+    "FORMAT": [
+        {"ID": "GT", "Number": "1", "Type": "String", "Description": "Unphased genotype"},
+        {"ID": "REPCN", "Number": "2", "Type": "Float", "Description": "Number of repeat units spanned by each allele"},
+        {"ID": "REPCI1", "Number": "2", "Type": "Integer", "Description": "95% CI min,max on repeat counts of first allele"},
+        {"ID": "REPCI2", "Number": "2", "Type": "Integer", "Description": "95% CI min,max on repeat counts of second allele"},
+        {"ID": "OUTLIER", "Number": "2", "Type": "Integer", "Description": "Allelic population outlier flags (0/1) assigned by STRipy"},
+        {"ID": "ZSCORE", "Number": "2", "Type": "Float", "Description": "Allelic population Z-scores assigned by STRipy"},
+        {"ID": "DP", "Number": "1", "Type": "Integer", "Description": "Total Depth"},
+        {"ID": "STR_FILTER", "Number": ".", "Type": "String", "Description": "Filter status assigned by STRipy"},
+    ],
+}
+
+
+def write_multisample_vcf(samples, out_path, contigs=None):
+    """
+    samples: list of (sample_name, loci_dict) tuples
+    loci_dict: dict keyed by locus_id -> locus data
+    """
+    header = pysam.VariantHeader()
+    header.add_meta("source", value="STRipy2VCF")
+    header.add_meta("ALT", items=[("ID", "STR"), ("Description", "Short tandem repeat")])
+    for info in VCF_HEADER["INFO"]:
+        header.add_meta("INFO", items=list(info.items()))
+    for fmt in VCF_HEADER["FORMAT"]:
+        header.add_meta("FORMAT", items=list(fmt.items()))
+
+    canonical = {}
+    for _, loci in samples:
+        for locus_id, loc in loci.items():
+            canonical.setdefault(locus_id, loc)
+
+    sorted_loci = sorted(canonical.values(), key=lambda x: (chrom_key(x["chrom"]), x["pos"]))
+
+    if contigs is not None:
+        for name, length in contigs:
+            header.contigs.add(name, length=length)
+    else:
+        for chrom_name in dict.fromkeys(loc["chrom"] for loc in sorted_loci):
+            header.contigs.add(chrom_name)
+
+    for sample_name, _ in samples:
+        header.add_sample(sample_name)
+
+    with pysam.VariantFile(out_path, mode="w", header=header) as vf:
+        for loc in sorted_loci:
+            rec = header.new_record()
+            rec.contig = loc["chrom"]
+            rec.start = loc["pos"] - 1
+            rec.stop = loc["end"]
+            rec.id = str(loc["id"])
+            rec.ref = "N"
+            rec.alts = ("<STR>",)
+            rec.filter.add(loc["filter"] if loc["filter"] else "PASS")
+            rec.info["SVTYPE"] = "STR"
+            if loc["motif"]:
+                rec.info["RU"] = loc["motif"]
+            if loc["period"]:
+                rec.info["PERIOD"] = int(loc["period"])
+            rec.info["DISEASES"] = loc["diseases"]
+            rec.info["LOCUS"] = loc["id"]
+
+            for sample_name, loci in samples:
+                s_loc = loci.get(loc["id"])
+                s = rec.samples[sample_name]
+                s["GT"] = (".", ".")
+                if s_loc is None:
+                    s["REPCN"] = (None, None)
+                    s["REPCI1"] = (0, 0)
+                    s["REPCI2"] = (0, 0)
+                    s["OUTLIER"] = (None, None)
+                    s["ZSCORE"] = (None, None)
+                    s["DP"] = None
+                    s["STR_FILTER"] = ["."]
+                else:
+                    s["REPCN"] = (s_loc["a1_rep"], s_loc["a2_rep"])
+                    s["REPCI1"] = s_loc["a1_ci"]
+                    s["REPCI2"] = s_loc["a2_ci"]
+                    s["OUTLIER"] = (s_loc["a1_out"], s_loc["a2_out"])
+                    s["ZSCORE"] = (s_loc["a1_z"], s_loc["a2_z"])
+                    s["DP"] = int(s_loc["coverage"])
+                    s["STR_FILTER"] = [str(s_loc["filter"])] if s_loc["filter"] else ["PASS"]
+
+            vf.write(rec)
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Convert STRipy JSON output(s) into a multi-sample VCF with SV-style STR annotations.")
+    ap.add_argument("--json", required=True, nargs="+", help="STRipy JSON report(s); one per sample")
+    ap.add_argument("-o", "--out", required=True, help="Output VCF")
+    ap.add_argument("--sample-names", nargs="+", default=None, help="Sample names (must match number of --json files if provided; defaults to ID extracted from JobDetails.InputFile)")
+    ap.add_argument("--reference", default=None, help="Optional reference FASTA for contig lengths")
+    args = ap.parse_args()
+
+    if args.sample_names and len(args.sample_names) != len(args.json):
+        ap.error(f"--sample-names count ({len(args.sample_names)}) must match --json count ({len(args.json)})")
+
+    overrides = args.sample_names or [None] * len(args.json)
+    samples = [load_sample(p, name) for p, name in zip(args.json, overrides)]
+
+    contigs = None
+    if args.reference:
+        reference = Fasta(args.reference, as_raw=True, read_ahead=1000000)
+        contigs = [(name, len(reference[name])) for name in reference.keys()]
+        reference.close()
+
+    write_multisample_vcf(samples, args.out, contigs=contigs)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/cpg_flow_stripy/stages.py
+++ b/src/cpg_flow_stripy/stages.py
@@ -166,7 +166,7 @@ class ParseGffMapping(stage.MultiCohortStage):
         return self.make_outputs(multicohort, data=output, jobs=job)
 
 
-@stage.stage(required_stages=[ParseGffMapping, RunStripy])
+@stage.stage(analysis_type='vcf', analysis_keys=['joint'], required_stages=[ParseGffMapping, RunStripy])
 class MakeStripyJointCall(stage.DatasetStage):
     """Takes the STRipy JSON files, interprets as VCFs, glues together into a joint call."""
 

--- a/src/cpg_flow_stripy/stages.py
+++ b/src/cpg_flow_stripy/stages.py
@@ -6,10 +6,10 @@ See https://gitlab.com/andreassh/stripy-pipeline
 
 from typing import Any
 
-from cpg_flow import stage, targets
+from cpg_flow import stage, targets, workflow
 from cpg_utils import Path, config, to_path
 
-from cpg_flow_stripy.jobs import stripy
+from cpg_flow_stripy.jobs import convert_gff, create_stripy_joint_call, stripy
 from cpg_flow_stripy.utils import get_loci_lists
 
 
@@ -66,7 +66,7 @@ class RunStripy(stage.SequencingGroupStage):
             job_attrs=self.get_job_attrs(sequencing_group),
         )
 
-        return self.make_outputs(sequencing_group, data=outputs, jobs=[j])
+        return self.make_outputs(sequencing_group, data=outputs, jobs=j)
 
 
 @stage.stage(required_stages=RunStripy)
@@ -146,3 +146,47 @@ class MakeIndexPage(stage.DatasetStage):
         )
 
         return self.make_outputs(dataset, data=outputs, jobs=job)
+
+
+@stage.stage
+class ParseGffMapping(stage.MultiCohortStage):
+    """Read in a GFF3 file, parse into a Gene Symbol: Gene ID mapping."""
+
+    def expected_outputs(self, multicohort: targets.MultiCohort) -> Path:
+        return (
+            to_path(config.config_retrieve(['storage', 'common', 'default']))
+            / 'references'
+            / 'stripy'
+            / 'symbol_id_map.json'
+        )
+
+    def queue_jobs(self, multicohort: targets.MultiCohort, inputs: stage.StageInput) -> stage.StageOutput:
+        output = self.expected_outputs(multicohort)
+        job = convert_gff.create_gff_conversion_job(output)
+        return self.make_outputs(multicohort, data=output, jobs=job)
+
+
+@stage.stage(required_stages=[ParseGffMapping, RunStripy])
+class MakeStripyJointCall(stage.DatasetStage):
+    """Takes the STRipy JSON files, interprets as VCFs, glues together into a joint call."""
+
+    def expected_outputs(self, dataset: targets.Dataset) -> dict[str, Path]:
+        return {'joint': dataset.prefix() / 'stripy' / dataset.get_alignment_inputs_hash() / 'joint_call.vcf.bgz'}
+
+    def queue_jobs(self, dataset: targets.Dataset, inputs: stage.StageInput) -> stage.StageOutput:
+        output = self.expected_outputs(dataset)
+
+        # pull all single SG outputs from the STRipy stage
+        sg_inputs = inputs.as_dict_by_target(RunStripy)
+
+        # STRipy JSONs relating SG IDs in this Dataset
+        dataset_jsons = {sgid: sg_inputs[sgid]['json'] for sgid in dataset.get_sequencing_group_ids()}
+
+        # find the gene ID lookup file
+        mapping = inputs.as_path(target=workflow.get_multicohort(), stage=ParseGffMapping)
+
+        job = create_stripy_joint_call.create_joint_call(
+            json_paths=dataset_jsons, gene_lookup=mapping, output=output['joint']
+        )
+
+        return self.make_outputs(dataset, data=output, jobs=job)

--- a/src/cpg_flow_stripy/stages.py
+++ b/src/cpg_flow_stripy/stages.py
@@ -7,7 +7,7 @@ See https://gitlab.com/andreassh/stripy-pipeline
 from typing import Any
 
 from cpg_flow import stage, targets
-from cpg_utils import Path, config
+from cpg_utils import Path, config, to_path
 
 from cpg_flow_stripy.jobs import stripy
 from cpg_flow_stripy.utils import get_loci_lists
@@ -15,13 +15,12 @@ from cpg_flow_stripy.utils import get_loci_lists
 
 def _update_meta(output_path: str) -> dict[str, Any]:
     """Add the detected outlier loci to the analysis meta."""
-    from cloudpathlib.anypath import to_anypath  # noqa: PLC0415
 
     # Munge JSON path into log path
     log_path = output_path.replace('.json', '.log.txt')
 
     outlier_loci = {}
-    with to_anypath(log_path).open() as f:
+    with to_path(log_path).open() as f:
         for line in f:
             if not line.strip().rstrip():
                 continue

--- a/src/cpg_flow_stripy/stages.py
+++ b/src/cpg_flow_stripy/stages.py
@@ -157,7 +157,7 @@ class ParseGffMapping(stage.MultiCohortStage):
             to_path(config.config_retrieve(['storage', 'common', 'default']))
             / 'references'
             / 'stripy'
-            / 'symbol_id_map.json'
+            / 'gene_symbol_to_id_map.json'
         )
 
     def queue_jobs(self, multicohort: targets.MultiCohort, inputs: stage.StageInput) -> stage.StageOutput:

--- a/src/cpg_flow_stripy/stages.py
+++ b/src/cpg_flow_stripy/stages.py
@@ -150,7 +150,7 @@ class MakeIndexPage(stage.DatasetStage):
 
 @stage.stage
 class ParseGffMapping(stage.MultiCohortStage):
-    """Read in a GFF3 file, parse into a Gene Symbol: Gene ID mapping."""
+    """Read in a GFF3 file, parse into a {Gene Symbol: Gene ID} mapping."""
 
     def expected_outputs(self, multicohort: targets.MultiCohort) -> Path:
         return (

--- a/test/test_stripy_to_vcf.py
+++ b/test/test_stripy_to_vcf.py
@@ -1,0 +1,81 @@
+"""Tests for stripy_to_vcf multi-sample VCF generation."""
+
+import math
+
+import pysam
+import pytest
+
+from cpg_flow_stripy.scripts.stripy_to_vcf import write_multisample_vcf
+
+
+def _make_locus(locus_id, chrom, pos, end, motif, a1_rep, a2_rep, coverage=30, filt="PASS"):
+    return {
+        "id": locus_id,
+        "chrom": chrom,
+        "pos": pos,
+        "end": end,
+        "motif": motif,
+        "period": len(motif),
+        "a1_rep": float(a1_rep),
+        "a2_rep": float(a2_rep) if a2_rep is not None else None,
+        "a1_ci": (a1_rep, a1_rep),
+        "a2_ci": (a2_rep, a2_rep) if a2_rep is not None else (0, 0),
+        "a1_out": 0,
+        "a2_out": 0,
+        "a1_z": 0.5,
+        "a2_z": 0.5,
+        "coverage": coverage,
+        "filter": filt,
+        "diseases": "DIS1",
+    }
+
+
+LOCUS_A = _make_locus("LOCUS_A", "chr1", 1000, 1050, "CAG", 10, 12)
+LOCUS_B = _make_locus("LOCUS_B", "chr1", 2000, 2050, "GCN", 5, 5)
+LOCUS_C = _make_locus("LOCUS_C", "chr2", 3000, 3050, "AT", 20, 22)
+
+
+@pytest.fixture()
+def two_sample_vcf(tmp_path):
+    """
+    SAMPLE1 has all three loci.
+    SAMPLE2 has only LOCUS_A and LOCUS_C — LOCUS_B is absent.
+    """
+    sample1_loci = {loc["id"]: loc for loc in [LOCUS_A, LOCUS_B, LOCUS_C]}
+    sample2_loci = {loc["id"]: loc for loc in [LOCUS_A, LOCUS_C]}
+
+    out = tmp_path / "multi.vcf"
+    write_multisample_vcf(
+        [("SAMPLE1", sample1_loci), ("SAMPLE2", sample2_loci)],
+        str(out),
+    )
+    return pysam.VariantFile(str(out))
+
+
+def test_sample_names(two_sample_vcf):
+    assert list(two_sample_vcf.header.samples) == ["SAMPLE1", "SAMPLE2"]
+
+
+def test_all_loci_present(two_sample_vcf):
+    ids = [rec.id for rec in two_sample_vcf.fetch()]
+    assert set(ids) == {"LOCUS_A", "LOCUS_B", "LOCUS_C"}
+
+
+def test_present_sample_has_data(two_sample_vcf):
+    for rec in two_sample_vcf.fetch():
+        if rec.id == "LOCUS_B":
+            s = rec.samples["SAMPLE1"]
+            assert s["REPCN"] == (5.0, 5.0)
+            assert s["DP"] == 30
+            assert s["STR_FILTER"] == ("PASS",)
+
+
+def test_missing_sample_placeholders(two_sample_vcf):
+    """SAMPLE2 has no data for LOCUS_B — all FORMAT fields should be missing/null."""
+    for rec in two_sample_vcf.fetch():
+        if rec.id == "LOCUS_B":
+            s = rec.samples["SAMPLE2"]
+            # Numeric fields should be None / nan
+            assert all(v is None or (isinstance(v, float) and math.isnan(v)) for v in s["REPCN"])
+            assert s["DP"] is None
+            assert s["STR_FILTER"] == (".",)

--- a/test/test_stripy_to_vcf.py
+++ b/test/test_stripy_to_vcf.py
@@ -21,6 +21,8 @@ def _make_locus(locus_id, chrom, pos, end, motif, a1_rep, a2_rep, coverage=30, f
         'a1_ci': (a1_rep, a1_rep),
         'a2_ci': (a2_rep, a2_rep) if a2_rep is not None else (0, 0),
         'a1_out': 0,
+        'a1_range': 'pathogenic',
+        'a2_range': None,
         'a2_out': 0,
         'a1_z': 0.5,
         'a2_z': 0.5,

--- a/test/test_stripy_to_vcf.py
+++ b/test/test_stripy_to_vcf.py
@@ -8,31 +8,31 @@ import pytest
 from cpg_flow_stripy.scripts.stripy_to_vcf import write_multisample_vcf
 
 
-def _make_locus(locus_id, chrom, pos, end, motif, a1_rep, a2_rep, coverage=30, filt="PASS"):
+def _make_locus(locus_id, chrom, pos, end, motif, a1_rep, a2_rep, coverage=30, filt='PASS') -> dict:
     return {
-        "id": locus_id,
-        "chrom": chrom,
-        "pos": pos,
-        "end": end,
-        "motif": motif,
-        "period": len(motif),
-        "a1_rep": float(a1_rep),
-        "a2_rep": float(a2_rep) if a2_rep is not None else None,
-        "a1_ci": (a1_rep, a1_rep),
-        "a2_ci": (a2_rep, a2_rep) if a2_rep is not None else (0, 0),
-        "a1_out": 0,
-        "a2_out": 0,
-        "a1_z": 0.5,
-        "a2_z": 0.5,
-        "coverage": coverage,
-        "filter": filt,
-        "diseases": "DIS1",
+        'id': locus_id,
+        'chrom': chrom,
+        'pos': pos,
+        'end': end,
+        'motif': motif,
+        'period': len(motif),
+        'a1_rep': float(a1_rep),
+        'a2_rep': float(a2_rep) if a2_rep is not None else None,
+        'a1_ci': (a1_rep, a1_rep),
+        'a2_ci': (a2_rep, a2_rep) if a2_rep is not None else (0, 0),
+        'a1_out': 0,
+        'a2_out': 0,
+        'a1_z': 0.5,
+        'a2_z': 0.5,
+        'coverage': coverage,
+        'filter': filt,
+        'diseases': 'DIS1',
     }
 
 
-LOCUS_A = _make_locus("LOCUS_A", "chr1", 1000, 1050, "CAG", 10, 12)
-LOCUS_B = _make_locus("LOCUS_B", "chr1", 2000, 2050, "GCN", 5, 5)
-LOCUS_C = _make_locus("LOCUS_C", "chr2", 3000, 3050, "AT", 20, 22)
+LOCUS_A = _make_locus('LOCUS_A', 'chr1', 1000, 1050, 'CAG', 10, 12)
+LOCUS_B = _make_locus('LOCUS_B', 'chr1', 2000, 2050, 'GCN', 5, 5)
+LOCUS_C = _make_locus('LOCUS_C', 'chr2', 3000, 3050, 'AT', 20, 22)
 
 
 @pytest.fixture()
@@ -41,41 +41,41 @@ def two_sample_vcf(tmp_path):
     SAMPLE1 has all three loci.
     SAMPLE2 has only LOCUS_A and LOCUS_C — LOCUS_B is absent.
     """
-    sample1_loci = {loc["id"]: loc for loc in [LOCUS_A, LOCUS_B, LOCUS_C]}
-    sample2_loci = {loc["id"]: loc for loc in [LOCUS_A, LOCUS_C]}
+    sample1_loci = {loc['id']: loc for loc in [LOCUS_A, LOCUS_B, LOCUS_C]}
+    sample2_loci = {loc['id']: loc for loc in [LOCUS_A, LOCUS_C]}
 
-    out = tmp_path / "multi.vcf"
+    out = tmp_path / 'multi.vcf'
     write_multisample_vcf(
-        [("SAMPLE1", sample1_loci), ("SAMPLE2", sample2_loci)],
+        [('SAMPLE1', sample1_loci), ('SAMPLE2', sample2_loci)],
         str(out),
     )
     return pysam.VariantFile(str(out))
 
 
 def test_sample_names(two_sample_vcf):
-    assert list(two_sample_vcf.header.samples) == ["SAMPLE1", "SAMPLE2"]
+    assert list(two_sample_vcf.header.samples) == ['SAMPLE1', 'SAMPLE2']
 
 
 def test_all_loci_present(two_sample_vcf):
     ids = [rec.id for rec in two_sample_vcf.fetch()]
-    assert set(ids) == {"LOCUS_A", "LOCUS_B", "LOCUS_C"}
+    assert set(ids) == {'LOCUS_A', 'LOCUS_B', 'LOCUS_C'}
 
 
 def test_present_sample_has_data(two_sample_vcf):
     for rec in two_sample_vcf.fetch():
-        if rec.id == "LOCUS_B":
-            s = rec.samples["SAMPLE1"]
-            assert s["REPCN"] == (5.0, 5.0)
-            assert s["DP"] == 30
-            assert s["STR_FILTER"] == ("PASS",)
+        if rec.id == 'LOCUS_B':
+            s = rec.samples['SAMPLE1']
+            assert s['REPCN'] == (5.0, 5.0)
+            assert s['DP'] == 30
+            assert s['STR_FILTER'] == ('PASS',)
 
 
 def test_missing_sample_placeholders(two_sample_vcf):
     """SAMPLE2 has no data for LOCUS_B — all FORMAT fields should be missing/null."""
     for rec in two_sample_vcf.fetch():
-        if rec.id == "LOCUS_B":
-            s = rec.samples["SAMPLE2"]
+        if rec.id == 'LOCUS_B':
+            s = rec.samples['SAMPLE2']
             # Numeric fields should be None / nan
-            assert all(v is None or (isinstance(v, float) and math.isnan(v)) for v in s["REPCN"])
-            assert s["DP"] is None
-            assert s["STR_FILTER"] == (".",)
+            assert all(v is None or (isinstance(v, float) and math.isnan(v)) for v in s['REPCN'])
+            assert s['DP'] is None
+            assert s['STR_FILTER'] == ('.',)


### PR DESCRIPTION
# Purpose

  - We currently generate the STRipy results in a STR-specific workflow, but haven't been able to combine them into a pseudo-joint-call format which is Talos/Seqr friendly

## Proposed Changes

  - Borrows very heavily from GATK-SV's ongoing work to incorporate STRipy into their workflow and VCFs. See [here](https://github.com/broadinstitute/gatk-sv/blob/7eb2af1feea9f81a390caff211f6832c6e7f7ac5/src/stripy/stripy_to_vcf.py) for a JSON->VCF script, and [here](https://github.com/broadinstitute/gatk-sv/blob/main/wdl/StripyWorkflow.wdl) for the broader STRipy workflow
   - This process aims to expand the GATK single sample JSON->VCF conversion, and integrate it as a Dataset-wide step in our STR workflow, generating a joint-call suitable for integration into other analysis tools
   - Adds a new stage to parse a GFF file into a `Symbol: ENSG` mapping (STRipy only has locus names, not ENSGs)
   - Adds a new stage to pull all STRipy JSONs for a dataset, combine them into a multisample VCF format

This is relatively conservative at the moment - only using loci in the `stripy.loci_lists.default_with_exclusions` list. Talos should handle the incidentalome via PanelApp, but we're treading lightly for now

## Semi-related

  - changes the pin of CPG-Flow to be looser
  - changes the dockerfile base image

## Checklist

- [ ] Related GitHub Issue created
- [x] Tests covering new change
- [x] Linting checks pass
