### PR TITLE
Pull in path & normal ranges

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM australia-southeast1-docker.pkg.dev/cpg-common/images/cpg_hail_gcloud:0.2.138.cpg1-1
 
 ENV PYTHONDONTWRITEBYTECODE=1
-ENV VERSION=0.4.1
+ENV VERSION=0.4.2
 
 WORKDIR /cpg_flow_stripy
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The short-read data is processed at the sequencing group level, and STRipy repor
 ```bash
 analysis-runner \
     --skip-repo-checkout \
-    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-stripy:0.4.1-1 \
+    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-stripy:0.4.2-1 \
     --config src/cpg_flow_stripy/config_template.toml \
     --config stripy_loci.toml \  # containing the inputs_cohorts and sequencing_type
     --dataset seqr \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name='cpg_flow_stripy'
 description='STR calling and report generation, implemented in CPG-Flow'
 readme = "README.md"
 requires-python = ">=3.10,<3.12"
-version="0.4.1"
+version="0.4.2"
 license={ "file" = "LICENSE" }
 classifiers=[
     'Environment :: Console',
@@ -95,7 +95,7 @@ hail = ["hail"]
 inline-quotes = "single"
 
 [tool.bumpversion]
-current_version = "0.4.1"
+current_version = "0.4.2"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 commit = true

--- a/src/cpg_flow_stripy/scripts/stripy_to_vcf.py
+++ b/src/cpg_flow_stripy/scripts/stripy_to_vcf.py
@@ -89,9 +89,11 @@ def _ci_tuple(allele: dict[str, dict[str, int]]) -> tuple[int, int]:
 
 def parse_disease_ranges(content: dict[str, str | dict[str, int]]) -> str:
     """
-    Read the CorrespondingDisease block of the JSON block.
-    This is a hybrid String of normal, intermediate, and pathogenic range.
-    These occur per-disease, but there can be multiple per allele.
+    Read the CorrespondingDisease content of the locus' JSON dictionary.
+    This creates a hybrid String of Gene, MOI, normal and intermediate ranges, and pathogenic threshold.
+    These occur per-disease, and there can be multiple per allele.
+
+    example results: "HD__AD__min9max26__min27max35__36" or "DMD__XLR__min11max33__.__59"
 
     Args:
         content: the dictionary from STRipy's CorrespondingDisease data block

--- a/src/cpg_flow_stripy/scripts/stripy_to_vcf.py
+++ b/src/cpg_flow_stripy/scripts/stripy_to_vcf.py
@@ -87,6 +87,39 @@ def _ci_tuple(allele: dict[str, dict[str, int]]) -> tuple[int, int]:
     return allele['CI'].get('Min', 0), allele['CI'].get('Max', 0)
 
 
+def parse_disease_ranges(content: dict[str, str | dict[str, int]]) -> str:
+    """
+    Read the CorrespondingDisease block of the JSON block.
+    This is a hybrid String of normal, intermediate, and pathogenic range.
+    These occur per-disease, but there can be multiple per allele.
+
+    Args:
+        content: the dictionary from STRipy's CorrespondingDisease data block
+
+    Returns:
+        A single aggregated String for all the details
+    """
+    # get the symbol for this disease
+    disease = content['DiseaseSymbol']
+
+    # the inheritance pattern
+    inheritance = content['Inheritance']
+
+    # parse the normal range, or '.'
+    normal_range = content['NormalRange']
+    normal = '.' if normal_range == 'NA' else f'min{normal_range["Min"]}max{normal_range["Max"]}'
+
+    # parse the intermediate range, or '.'
+    inter_range = content['IntermediateRange']
+    intermediate = '.' if inter_range == 'NA' else f'min{inter_range["Min"]}max{inter_range["Max"]}'
+
+    # get the pathogenic cutoff used for this disease
+    path = content['PathogenicCutoff']
+
+    # pull it all together
+    return f'{disease}__{inheritance}__{normal}__{intermediate}__{path}'
+
+
 def load_sample(json_path: str) -> tuple[str, dict]:
     """Load a STRipy JSON and return (sample_name, loci_dict keyed by locus_id)."""
     with to_path(json_path).open() as f:
@@ -105,12 +138,15 @@ def load_sample(json_path: str) -> tuple[str, dict]:
         for locus_name, locus in entry.items():
             tl = locus['TargetedLocus']
 
+            # create a |-delimited string for all ranges for all relevant disease for this locus
+            disease_deets = '|'.join(parse_disease_ranges(corr) for corr in tl['CorrespondingDisease'].values())
+
             # add flexibility if the Alleles aren't populated at all
             if 'Alleles' not in locus:
                 explain_string = f'Parsing {sample_name}, locus {tl["LocusID"]}, no Alleles present - skipping. '
                 if 'Filter' in locus:
                     explain_string += f'Filter: {locus["Filter"]} - '
-                logging.warning(explain_string)
+                logging.debug(explain_string)
                 continue
 
             parsed = parse_coords(tl['Coordinates'])
@@ -141,6 +177,7 @@ def load_sample(json_path: str) -> tuple[str, dict]:
                 'coverage': locus['Metadata']['Coverage'],
                 'filter': locus['Filter'],
                 'diseases': '|'.join(sorted({meta['DiseaseSymbol'] for meta in tl['CorrespondingDisease'].values()})),
+                'disease_details': disease_deets,
             }
 
     return sample_name, loci
@@ -165,6 +202,12 @@ VCF_HEADER = {
     'FORMAT': [
         {'ID': 'GT', 'Number': '1', 'Type': 'String', 'Description': 'Unphased genotype'},
         {'ID': 'REPCN', 'Number': '2', 'Type': 'Float', 'Description': 'Number of repeat units spanned by each allele'},
+        {
+            'ID': 'DISEASE_DETAILS',
+            'Number': '1',
+            'Type': 'String',
+            'Description': '|-delimited details for each disease.',
+        },
         {
             'ID': 'REPCI1',
             'Number': '2',
@@ -298,6 +341,7 @@ def write_multisample_vcf(
                     s['ZSCORE'] = (None, None)
                     s['DP'] = None
                     s['STR_FILTER'] = ['.']
+                    s['DISEASE_DETAILS'] = '.'
                 else:
                     s['GT'] = (convert_range_to_gt(s_loc['a1_range']), convert_range_to_gt(s_loc['a2_range']))
                     s['REPCN'] = (s_loc['a1_rep'], s_loc['a2_rep'])
@@ -307,6 +351,7 @@ def write_multisample_vcf(
                     s['ZSCORE'] = (s_loc['a1_z'], s_loc['a2_z'])
                     s['DP'] = int(s_loc['coverage'])
                     s['STR_FILTER'] = [str(s_loc['filter'])] if s_loc['filter'] else ['PASS']
+                    s['DISEASE_DETAILS'] = s_loc['disease_details']
 
             vf.write(rec)
 

--- a/src/cpg_flow_stripy/scripts/stripy_to_vcf.py
+++ b/src/cpg_flow_stripy/scripts/stripy_to_vcf.py
@@ -106,12 +106,16 @@ def parse_disease_ranges(content: dict[str, str | dict[str, int]]) -> str:
     inheritance = content['Inheritance']
 
     # parse the normal range, or '.'
-    normal_range = content['NormalRange']
-    normal = '.' if normal_range == 'NA' else f'min{normal_range["Min"]}max{normal_range["Max"]}'
+    normal_range: dict[str, int] | str = content['NormalRange']
+    normal = '.'
+    if isinstance(normal_range, dict):
+        normal = f'min{normal_range["Min"]}max{normal_range["Max"]}'
 
     # parse the intermediate range, or '.'
-    inter_range = content['IntermediateRange']
-    intermediate = '.' if inter_range == 'NA' else f'min{inter_range["Min"]}max{inter_range["Max"]}'
+    inter_range: dict[str, int] | str = content['IntermediateRange']
+    intermediate = '.'
+    if isinstance(inter_range, dict):
+        intermediate = f'min{inter_range["Min"]}max{inter_range["Max"]}'
 
     # get the pathogenic cutoff used for this disease
     path = content['PathogenicCutoff']
@@ -206,7 +210,7 @@ VCF_HEADER = {
             'ID': 'DISEASE_DETAILS',
             'Number': '1',
             'Type': 'String',
-            'Description': '|-delimited details for each disease.',
+            'Description': '|-delimited details for each disease, in the form "diseaseSymbol__normal__intermediate__pathogenic", where normal and intermediate are in the form minXmaxY (or .), and pathogenic is a single integer.',  # noqa: E501
         },
         {
             'ID': 'REPCI1',
@@ -276,8 +280,10 @@ def get_gene_lookup(map_path: str | None = None) -> dict[str, str]:
     return lookup
 
 
-def write_multisample_vcf(
-    samples: list[tuple[str, dict[str, dict]]], out_path: str, gene_map: str | None = None
+def write_multisample_vcf(  # noqa: PLR0915
+    samples: list[tuple[str, dict[str, dict]]],
+    out_path: str,
+    gene_map: str | None = None,
 ) -> None:
     """
     Integrate the per-sample data into a union VCF

--- a/src/cpg_flow_stripy/scripts/stripy_to_vcf.py
+++ b/src/cpg_flow_stripy/scripts/stripy_to_vcf.py
@@ -210,7 +210,7 @@ VCF_HEADER = {
             'ID': 'DISEASE_DETAILS',
             'Number': '1',
             'Type': 'String',
-            'Description': '|-delimited details for each disease, in the form "diseaseSymbol__normal__intermediate__pathogenic", where normal and intermediate are in the form minXmaxY (or .), and pathogenic is a single integer.',  # noqa: E501
+            'Description': '|-delimited details for each disease, in the form diseaseSymbol__normal__intermediate__pathogenic',  # noqa: E501
         },
         {
             'ID': 'REPCI1',

--- a/test/test_stripy_to_vcf.py
+++ b/test/test_stripy_to_vcf.py
@@ -29,6 +29,7 @@ def _make_locus(locus_id, chrom, pos, end, motif, a1_rep, a2_rep, coverage=30, f
         'coverage': coverage,
         'filter': filt,
         'diseases': 'DIS1',
+        'disease_details': 'Something|something_else',
     }
 
 


### PR DESCRIPTION
# Purpose

  - The current joint-call generator doesn't include the normal, intermediate, and pathogenic thresholds

## Proposed Changes

  - Adds a new block to the vcf containing 'disease details'
  - These disease details aggregate the disease Symbol, MOI, normal range, intermediate range, and pathogenic range for each of the diseases relevant to the locus

## Reasoning 

This is chucked into the Entry instead of the INFO block, because the STRipy 'joint-call' generator will work when given multiple STRipy JSON files generated from different catalogs, or results based on various custom loci. Because of this, the exact thresholds can't be generalised to the whole locus across all samples. Each 'genotype' is specific to the thresholds in that particular analysis.

I've dealt with the various values by combining all the details into a single String. These can easily be decomposed later using a regular expression. An alternative would be recording all the different values separately
- list of disease symbols
- list of Inheritance patterns
- list of normal ranges (or missing)
- list of intermediate ranges (or missing)
- list of pathogenic thresholds

That would also work, and wouldn't require the VCF values to be post processed as much to be usable, but needs several field values to be zipped together, and for each to be checked for missingness. IMO the current implementation is more easily parse-able by eye and in code, e.g. `HD__AD__min9max26__min27max35__36` or `DMD__XLR__min11max33__.__59`

## Checklist

- [ ] Related GitHub Issue created
- [ ] Tests covering new change
- [ ] Linting checks pass
